### PR TITLE
Fixed a bug where exception traceback was overridded wrongfully

### DIFF
--- a/tasker/executor/_executor.py
+++ b/tasker/executor/_executor.py
@@ -137,7 +137,6 @@ class Executor:
 
             return
         else:
-            exception_traceback = traceback.format_exc()
             self.on_failure(
                 task=task,
                 exception=exception,


### PR DESCRIPTION
It was due to our latest refactor, missed a line which cause our tracebacks to be None