### PR TITLE
Remove `multiprocessing.set_start_method` from Supervisor#__init__

### DIFF
--- a/tasker/supervisor.py
+++ b/tasker/supervisor.py
@@ -73,11 +73,6 @@ class Supervisor:
         self.should_work_event = threading.Event()
         self.should_work_event.set()
 
-        multiprocessing.set_start_method(
-            method='spawn',
-            force=True,
-        )
-
     def worker_watchdog(
         self,
         function,


### PR DESCRIPTION
multiprocessing.set_start_method should be called from `if __name__ ==
'__main__'` as stated in the
documentation(https://docs.python.org/3.4/library/multiprocessing.html?highlight=process#contexts-and-start-methods). Calling multiprocessing.set_start_method with force=True can lead to Semaphore leaks(https://github.com/pytorch/pytorch/issues/11727). As an alternative, we can do the following inside `worker/control/package.py` and `worker/control/worker.py`:
```
    try:
        multiprocessing.set_start_method(
            method='spawn',
        )
    except RuntimeError as exception:
        if str(exception) != 'context has already been set':
            raise
```